### PR TITLE
Update properties in documentation.

### DIFF
--- a/src/Data/Trie.hs
+++ b/src/Data/Trie.hs
@@ -15,7 +15,7 @@
 -- @
 -- 'fromList' . 'toList' ≡ 'id'
 -- 'toList' . 'fromString' ≡ (:[])
--- 'sort' . 'nub' . 'toList' . 'fromList' ≡ 'sort' . 'nub'
+-- 'toList' . 'fromList' ≡ 'sort' . 'nub'
 -- @
 
 module Data.Trie ( empty, insert, fromString, fromList


### PR DESCRIPTION
The third property listed was not strong and meant very little other than the elements of a list would not change given `toList . fromList`. However, the stronger claim can be made, that `toList . fromList = sort . nub`.

The extra newline at the end is just a remnant of me editing the file on GitHub.